### PR TITLE
Add expanded payout method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.bundle
 /coverage
 .DS_Store
+.idea

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,8 @@ Lint/EndAlignment:
 
 Style/Documentation:
   Enabled: false
+Style/FormatStringToken:
+  Enabled: false
 Style/IndentationWidth:
   Enabled: false
 Style/ElseAlignment:

--- a/README.md
+++ b/README.md
@@ -86,22 +86,22 @@ response.body
 ````
 
 ##### Performing a payout with expanded params:
-`credentials_type` must be either `"AUTHORIZATION"` or `"PASSWORD"`
-- If `credentials_type` is `"AUTHORIZATION"`, `token` is required
-- If `credentials_type` is `"PASSWORD"`, `user_name` and `password` are required
+If the orders type is `"url"`, `credentials` must be a dictionary containing one of the following:
+- `type: "AUTHORIZATION"` with a required `token` field
+- `type: "PASSWORD"` with required `user_name` and `password` fields
 ```ruby
 response = client.expanded_payout(
   payee_id: 42,
   client_reference_id: 43,
   amount: 100.0, 
+  currency: 'USD',
   description: "Foo Bar's order",
   seller_id: 44, 
   seller_name: "Foo Bar", 
   seller_url: "foo@bar.com", 
   seller_type: 'ECOMMERCE', 
   path: 'orders@path.com', 
-  credentials_type: 'AUTHORIZATION', 
-  token: 'fake_token'
+  credentials: { type: 'AUTHORIZATION', token: 'fake_token'}
 )
 
 response.body

--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ client.payee_details('fake-payee-id').body
     "AccountNumber"=>"123456789",
     "RoutingNumber"=>"121042882",
     "AccountType"=>"S"}}
+    
+```
+
+##### Performing a payout with expanded params:
+`credentials_type` must be either `"AUTHORIZATION"` or `"PASSWORD"`
+- If `credentials_type` is `"AUTHORIZATION"`, `token` is required
+- If `credentials_type` is `"PASSWORD"`, `user_name` and `password` are required
+```ruby
+client.expanded_payout(
+  payee_id: 42,
+  client_reference_id: 43,
+  amount: 100.0, 
+  description: "Foo Bar's order",
+  seller_id: 44, 
+  seller_name: "Foo Bar", 
+  seller_url: "foo@bar.com", 
+  seller_type: 'ECOMMERCE', 
+  path: 'orders@path.com', 
+  credentials_type: 'AUTHORIZATION', 
+  token: 'fake_token'
+)
 ```
 
 #### Console:

--- a/README.md
+++ b/README.md
@@ -66,12 +66,31 @@ client.payee_details('fake-payee-id').body
     
 ```
 
+##### Performing a normal payout:
+```ruby
+response = client.payout(
+  program_id: 'fake-partner-id',
+  payment_id: 43,
+  amount: 100.0,
+  payee_id: 42,
+  description: "Foo Bar's order"
+)
+
+response.body
+=> {
+    "Description" => "",
+      "PaymentID" => "1234",
+         "Status" => "000",
+     "PayoneerID" => "42"
+}
+````
+
 ##### Performing a payout with expanded params:
 `credentials_type` must be either `"AUTHORIZATION"` or `"PASSWORD"`
 - If `credentials_type` is `"AUTHORIZATION"`, `token` is required
 - If `credentials_type` is `"PASSWORD"`, `user_name` and `password` are required
 ```ruby
-client.expanded_payout(
+response = client.expanded_payout(
   payee_id: 42,
   client_reference_id: 43,
   amount: 100.0, 
@@ -84,6 +103,17 @@ client.expanded_payout(
   credentials_type: 'AUTHORIZATION', 
   token: 'fake_token'
 )
+
+response.body
+=> {
+       "audit_id" => 123456789,
+           "code" => 0,
+    "description" => "Success",
+      "payout_id" => "1234",
+         "amount" => 100.0,
+       "currency" => "USD",
+      "PaymentID" => "1234"
+}
 ```
 
 #### Console:

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -68,8 +68,8 @@ module Payoneer
         }
       }
 
-      encoded_credentials = 'Basic ' + Base64::encode64("#{configuration.username}:#{configuration.api_password}").chomp
-      response = RestClient.post "#{configuration.json_base_uri}/payouts", params.to_json, { content_type: 'application/json', accept: :json, Authorization: encoded_credentials }
+      encoded_credentials = 'Basic ' + Base64.encode64("#{configuration.username}:#{configuration.api_password}").chomp
+      response = RestClient.post "#{configuration.json_base_uri}/payouts", params.to_json, content_type: 'application/json', accept: :json, Authorization: encoded_credentials
       raise ResponseError.new(code: response.code, body: response.body) if response.code != 200
 
       hash = JSON.parse(response.body)

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -61,8 +61,8 @@ module Payoneer
             type: 'url',
             path: path,
             credentials: { # @TODO: What type of credentials? When should we expire?
-                type: 'AUTHORIZATION',
-                token: 'FILL'
+              type: 'AUTHORIZATION',
+              token: 'FILL_ME_IN'
             }
           }
         }

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -80,12 +80,7 @@ module Payoneer
       if hash.key?('Code')
         Response.new(hash['Code'], hash['Description'])
       else
-        hash = if block_given?
-          yield(hash)
-        else
-          hash
-        end
-
+        hash = block_given? ? yield(hash) : hash
         Response.new(Response::OK_STATUS_CODE, hash)
       end
     end
@@ -112,12 +107,7 @@ module Payoneer
       if hash.key?('Code')
         Response.new(hash['Code'], hash['Description'])
       else
-        hash = if block_given?
-          yield(hash)
-        else
-          hash
-        end
-
+        hash = block_given? ? yield(hash) : hash
         Response.new(Response::OK_STATUS_CODE, hash)
       end
     end

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -39,7 +39,7 @@ module Payoneer
       )
     end
 
-    # Includes additional items as needed to be Payoneer SAFE compliant (https://app.asana.com/0/440902128870182/473284740903863/f)
+    # Includes additional items as needed to be Payoneer SAFE compliant
     def expanded_payout(payee_id:, client_reference_id:, amount:, currency: 'USD', description:, payout_date: Time.now, seller_id:, seller_name:, seller_url:, seller_type: 'ECOMMERCE', path:)
       params = {
         payee_id: payee_id,

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -46,7 +46,7 @@ module Payoneer
     private
 
     def post(method_name, params = {})
-      response = RestClient.post(configuration.base_uri, {
+      response = RestClient.post(configuration.xml_base_uri, {
         mname: method_name,
         p1: configuration.username,
         p2: configuration.api_password,

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -40,7 +40,7 @@ module Payoneer
     end
 
     # Includes additional items as needed to be Payoneer SAFE compliant
-    def expanded_payout(payee_id:, client_reference_id:, amount:, currency: 'USD', description:, payout_date: Time.now, seller_id:, seller_name:, seller_url:, seller_type: 'ECOMMERCE', path:, credentials_type:, token: '', user_name: '', password: '')
+    def expanded_payout(payee_id:, client_reference_id:, amount:, currency:, description:, payout_date: Time.now, seller_id:, seller_name:, seller_url:, seller_type: 'ECOMMERCE', orders_type: 'url', path:, credentials:)
       params = {
         payee_id: payee_id,
         client_reference_id: client_reference_id,
@@ -58,14 +58,9 @@ module Payoneer
             }
           },
           orders: {
-            type: 'url',
+            type: orders_type,
             path: path,
-            credentials: {
-              type: credentials_type,
-              token: token,
-              user_name: user_name,
-              password: password
-            }
+            credentials: credentials
           }
         }
       }

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -40,7 +40,7 @@ module Payoneer
     end
 
     # Includes additional items as needed to be Payoneer SAFE compliant
-    def expanded_payout(payee_id:, client_reference_id:, amount:, currency: 'USD', description:, payout_date: Time.now, seller_id:, seller_name:, seller_url:, seller_type: 'ECOMMERCE', path:)
+    def expanded_payout(payee_id:, client_reference_id:, amount:, currency: 'USD', description:, payout_date: Time.now, seller_id:, seller_name:, seller_url:, seller_type: 'ECOMMERCE', path:, credentials_type:, token: '', user_name: '', password: '')
       params = {
         payee_id: payee_id,
         client_reference_id: client_reference_id,
@@ -60,9 +60,11 @@ module Payoneer
           orders: {
             type: 'url',
             path: path,
-            credentials: { # @TODO: What type of credentials? When should we expire?
-              type: 'AUTHORIZATION',
-              token: 'FILL_ME_IN'
+            credentials: {
+              type: credentials_type,
+              token: token,
+              user_name: user_name,
+              password: password
             }
           }
         }

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -39,6 +39,54 @@ module Payoneer
       )
     end
 
+    # Includes additional items as needed to be Payoneer SAFE compliant (https://app.asana.com/0/440902128870182/473284740903863/f)
+    def expanded_payout(payee_id:, client_reference_id:, amount:, currency: 'USD', description:, payout_date: Time.now, seller_id:, seller_name:, seller_url:, seller_type: 'ECOMMERCE', path:)
+      params = {
+        payee_id: payee_id,
+        client_reference_id: client_reference_id,
+        amount: amount,
+        currency: currency,
+        description: description,
+        payout_date: payout_date.strftime('%Y-%m-%d'),
+        orders_report: {
+          merchant: {
+            id: seller_id,
+            store: {
+              name: seller_name,
+              url: seller_url,
+              type: seller_type
+            }
+          },
+          orders: {
+            type: 'url',
+            path: path,
+            credentials: { # @TODO: What type of credentials? When should we expire?
+                type: 'AUTHORIZATION',
+                token: 'FILL'
+            }
+          }
+        }
+      }
+
+      encoded_credentials = 'Basic ' + Base64::encode64("#{configuration.username}:#{configuration.api_password}").chomp
+      response = RestClient.post "#{configuration.json_base_uri}/payouts", params.to_json, { content_type: 'application/json', accept: :json, Authorization: encoded_credentials }
+      raise ResponseError.new(code: response.code, body: response.body) if response.code != 200
+
+      hash = JSON.parse(response.body)
+
+      if hash.key?('Code')
+        Response.new(hash['Code'], hash['Description'])
+      else
+        hash = if block_given?
+          yield(hash)
+        else
+          hash
+        end
+
+        Response.new(Response::OK_STATUS_CODE, hash)
+      end
+    end
+
     def payout_details(payee_id:, payment_id:)
       post('GetPaymentStatus', p4: payee_id, p5: payment_id)
     end

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -75,6 +75,7 @@ module Payoneer
       raise ResponseError.new(code: response.code, body: response.body) if response.code != 200
 
       hash = JSON.parse(response.body)
+      hash['PaymentID'] = hash['payout_id'] # Keep consistent with the normal payout response body
 
       if hash.key?('Code')
         Response.new(hash['Code'], hash['Description'])

--- a/lib/payoneer/configuration.rb
+++ b/lib/payoneer/configuration.rb
@@ -18,8 +18,12 @@ module Payoneer
       @host || 'api.payoneer.com'
     end
 
-    def base_uri
-      @base_uri || "#{protocol}://#{host}/Payouts/HttpApi/API.aspx"
+    def xml_base_uri
+      @xml_base_uri || "#{protocol}://#{host}/Payouts/HttpApi/API.aspx"
+    end
+
+    def json_base_uri
+      @json_base_uri || "#{protocol}://#{host}/v2/programs/#{@partner_id}"
     end
   end
 end

--- a/payoneer-client.gemspec
+++ b/payoneer-client.gemspec
@@ -3,7 +3,7 @@
 # gem push payoneer-client-{VERSION}.gem
 Gem::Specification.new do |s|
   s.name        = 'payoneer-client'
-  s.version     = '0.3'
+  s.version     = '0.4'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = ['README.md']
 
-  s.required_ruby_version = '~> 2.2'
+  s.required_ruby_version = '~> 2.0'
 
   s.add_dependency 'activesupport', '~> 4.2'
   s.add_dependency 'rest-client', '~> 1.6'

--- a/payoneer-client.gemspec
+++ b/payoneer-client.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = ['README.md']
 
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '~> 2.2'
 
   s.add_dependency 'activesupport', '~> 4.2'
   s.add_dependency 'rest-client', '~> 1.6'

--- a/payoneer-client.gemspec
+++ b/payoneer-client.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = ['README.md']
 
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '~> 2.2'
 
-  s.add_dependency 'rest-client', '~> 1.6'
   s.add_dependency 'activesupport', '~> 4.2'
+  s.add_dependency 'rest-client', '~> 1.6'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -88,13 +88,13 @@ describe Payoneer::Client do
     let(:payee_id) { 42 }
     let(:client_reference_id) { 43 }
     let(:amount) { 100 }
+    let(:currency) { 'USD' }
     let(:description) { (Time.now - 10.days).strftime('%Y-%m-%d') }
     let(:seller_id) { 44 }
     let(:seller_name) { 'Fake Seller' }
     let(:seller_url) { 'http://tophatter.dev/users/1' }
     let(:path) { 'fake_s3@path.com' }
-    let(:credentials_type) { 'AUTHORIZATION' }
-    let(:token) { 'FILL_ME_IN' }
+    let(:credentials) { { type: 'AUTHORIZATION', token: 'fake' } }
     let(:endpoint) { "#{configuration.json_base_uri}/payouts" }
     let(:headers) { { content_type: 'application/json', accept: :json, Authorization: 'Basic ' + Base64.encode64("#{configuration.username}:#{configuration.api_password}").chomp } }
     let(:response) do
@@ -123,19 +123,14 @@ describe Payoneer::Client do
           orders: {
             type: 'url',
             path: path,
-            credentials: {
-              type: credentials_type,
-              token: token,
-              user_name: '',
-              password: ''
-            }
+            credentials: credentials
           }
         } }
     end
 
     it 'generates the correct response' do
       expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, params.to_json, headers).and_return(response)
-      response = client.expanded_payout(payee_id: payee_id, client_reference_id: client_reference_id, amount: amount, description: description, seller_id: seller_id, seller_name: seller_name, seller_url: seller_url, path: path, credentials_type: credentials_type, token: token)
+      response = client.expanded_payout(payee_id: payee_id, client_reference_id: client_reference_id, amount: amount, description: description, currency: currency, seller_id: seller_id, seller_name: seller_name, seller_url: seller_url, path: path, credentials: credentials)
       expect(response.ok?).to be_truthy
       expect(response.body).to include('payee_id' => payee_id, 'amount' => amount)
       expect(response.body).to include('orders_report')

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -93,6 +93,8 @@ describe Payoneer::Client do
     let(:seller_name) { 'Fake Seller' }
     let(:seller_url) { 'http://tophatter.dev/users/1' }
     let(:path) { 'fake_s3@path.com' }
+    let(:credentials_type) { 'AUTHORIZATION' }
+    let(:token) { 'FILL_ME_IN' }
     let(:endpoint) { "#{configuration.json_base_uri}/payouts" }
     let(:headers) { { content_type: 'application/json', accept: :json, Authorization: 'Basic ' + Base64.encode64("#{configuration.username}:#{configuration.api_password}").chomp } }
     let(:response) do
@@ -122,8 +124,10 @@ describe Payoneer::Client do
             type: 'url',
             path: path,
             credentials: {
-              type: 'AUTHORIZATION',
-              token: 'FILL_ME_IN' # @TODO: Fix this
+              type: credentials_type,
+              token: token,
+              user_name: '',
+              password: ''
             }
           }
         } }
@@ -131,7 +135,7 @@ describe Payoneer::Client do
 
     it 'generates the correct response' do
       expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, params.to_json, headers).and_return(response)
-      response = client.expanded_payout(payee_id: payee_id, client_reference_id: client_reference_id, amount: amount, description: description, seller_id: seller_id, seller_name: seller_name, seller_url: seller_url, path: path)
+      response = client.expanded_payout(payee_id: payee_id, client_reference_id: client_reference_id, amount: amount, description: description, seller_id: seller_id, seller_name: seller_name, seller_url: seller_url, path: path, credentials_type: credentials_type, token: token)
       expect(response.ok?).to be_truthy
       expect(response.body).to include('payee_id' => payee_id, 'amount' => amount)
       expect(response.body).to include('orders_report')

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -123,7 +123,7 @@ describe Payoneer::Client do
             path: path,
             credentials: {
               type: 'AUTHORIZATION',
-              token: 'FILL'
+              token: 'FILL_ME_IN' # @TODO: Fix this
             }
           }
         }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -83,4 +83,61 @@ describe Payoneer::Client do
       expect(response.body).to include('FirstName' => 'Foo', 'LastName' => 'Bar')
     end
   end
+
+  describe '#expanded_payout' do
+    let(:payee_id) { 42 }
+    let(:client_reference_id) { 43 }
+    let(:amount) { 100 }
+    let(:description) { (Time.now - 10.days).strftime('%Y-%m-%d') }
+    let(:seller_id) { 44 }
+    let(:seller_name) { 'Fake Seller' }
+    let(:seller_url) { 'http://tophatter.dev/users/1' }
+    let(:path) { 'fake_s3@path.com'}
+    let(:endpoint) { "#{configuration.json_base_uri}/payouts" }
+    let(:headers) { { content_type: 'application/json', accept: :json, Authorization: 'Basic ' + Base64::encode64("#{configuration.username}:#{configuration.api_password}").chomp} }
+    let(:response) do
+      mock = double
+      allow(mock).to receive(:code).and_return(200)
+      allow(mock).to receive(:body).and_return(params.to_json)
+      mock
+    end
+
+    let(:params) {
+      { payee_id: payee_id,
+        client_reference_id: client_reference_id,
+        amount: amount,
+        currency: 'USD',
+        description: description,
+        payout_date: Time.now.strftime('%Y-%m-%d'),
+        orders_report: {
+          merchant: {
+            id: seller_id,
+            store: {
+              name: seller_name,
+              url: seller_url,
+              type: 'ECOMMERCE'
+            }
+          },
+          orders: {
+            type: 'url',
+            path: path,
+            credentials: {
+              type: 'AUTHORIZATION',
+              token: 'FILL'
+            }
+          }
+        }
+      }
+    }
+
+    it 'generates the correct response' do
+      expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, params.to_json, headers).and_return(response)
+      response = client.expanded_payout(payee_id: payee_id, client_reference_id: client_reference_id, amount: amount, description: description, seller_id: seller_id, seller_name: seller_name, seller_url: seller_url, path: path)
+      expect(response.ok?).to be_truthy
+      expect(response.body).to include('payee_id' => payee_id, 'amount' => amount)
+      expect(response.body).to include('orders_report')
+      expect(response.body['orders_report']).to include('orders')
+      expect(response.body['orders_report']['orders']).to include('path' => path)
+    end
+  end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -92,9 +92,9 @@ describe Payoneer::Client do
     let(:seller_id) { 44 }
     let(:seller_name) { 'Fake Seller' }
     let(:seller_url) { 'http://tophatter.dev/users/1' }
-    let(:path) { 'fake_s3@path.com'}
+    let(:path) { 'fake_s3@path.com' }
     let(:endpoint) { "#{configuration.json_base_uri}/payouts" }
-    let(:headers) { { content_type: 'application/json', accept: :json, Authorization: 'Basic ' + Base64::encode64("#{configuration.username}:#{configuration.api_password}").chomp} }
+    let(:headers) { { content_type: 'application/json', accept: :json, Authorization: 'Basic ' + Base64.encode64("#{configuration.username}:#{configuration.api_password}").chomp } }
     let(:response) do
       mock = double
       allow(mock).to receive(:code).and_return(200)
@@ -102,7 +102,7 @@ describe Payoneer::Client do
       mock
     end
 
-    let(:params) {
+    let(:params) do
       { payee_id: payee_id,
         client_reference_id: client_reference_id,
         amount: amount,
@@ -126,9 +126,8 @@ describe Payoneer::Client do
               token: 'FILL_ME_IN' # @TODO: Fix this
             }
           }
-        }
-      }
-    }
+        } }
+    end
 
     it 'generates the correct response' do
       expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, params.to_json, headers).and_return(response)


### PR DESCRIPTION
## Task ##
The Payoneer Implementation Guide for Payoneer Payout Services REST API was updated in 2017. To be Payoneer SAFE compliant, all payouts for payees from China/HK must also contain additional information in the payload request.

See Appendix E in [PayoneerPayouts_IntegrationGuide REST API 4.16.pdf](https://github.com/tophatter/payoneer-api-ruby/files/1563775/PayoneerPayouts_IntegrationGuide.REST.API.4.16.pdf).


## Changes ##
- Add a new method `expanded_payout` that uses the new Payoneer API (json) to send the information needed in the payout
- Add a spec

## Todo ##
Once we confirm with Payoneer what we should do about the credentials for access to order urls, we can determine whether or not we need to send along a credentials params. Currently, we are sending a signed URL as the url for the orders data.

@cte 