### PR TITLE
Rescue from Restclient error

### DIFF
--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -109,7 +109,7 @@ module Payoneer
       end
     end
 
-    def create_response(hash, http_code)
+    def create_response(hash, http_code=Response::OK_STATUS_CODE)
       if hash.key?('Code')
         Response.new(hash['Code'], hash['Description'])
       else

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -66,17 +66,19 @@ module Payoneer
       }
 
       encoded_credentials = 'Basic ' + Base64.encode64("#{configuration.username}:#{configuration.api_password}").chomp
-      response = RestClient.post "#{configuration.json_base_uri}/payouts", params.to_json, content_type: 'application/json', accept: :json, Authorization: encoded_credentials
-      raise ResponseError.new(code: response.code, body: response.body) if response.code != 200
 
-      hash = JSON.parse(response.body)
-      hash['PaymentID'] = hash['payout_id'] # Keep consistent with the normal payout response body
+      begin
+        response = RestClient.post "#{configuration.json_base_uri}/payouts", params.to_json, content_type: 'application/json', accept: :json, Authorization: encoded_credentials
+        raise ResponseError.new(code: response.code, body: response.body) if response.code != 200
 
-      if hash.key?('Code')
-        Response.new(hash['Code'], hash['Description'])
-      else
-        hash = block_given? ? yield(hash) : hash
-        Response.new(Response::OK_STATUS_CODE, hash)
+        hash = JSON.parse(response.body)
+        hash['PaymentID'] = hash['payout_id'] # Keep consistent with the normal payout response body
+
+        create_response(hash)
+      rescue RestClient::BadRequest, RestClient::ResourceNotFound => e
+        hash = JSON.parse(e.response)
+
+        create_response(hash)
       end
     end
 
@@ -99,6 +101,15 @@ module Payoneer
       # @TODO: Validate that the response is XML?
       hash = Hash.from_xml(response.body).values.first
 
+      if hash.key?('Code')
+        Response.new(hash['Code'], hash['Description'])
+      else
+        hash = block_given? ? yield(hash) : hash
+        Response.new(Response::OK_STATUS_CODE, hash)
+      end
+    end
+
+    def create_response(hash)
       if hash.key?('Code')
         Response.new(hash['Code'], hash['Description'])
       else

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -69,16 +69,16 @@ module Payoneer
 
       begin
         response = RestClient.post "#{configuration.json_base_uri}/payouts", params.to_json, content_type: 'application/json', accept: :json, Authorization: encoded_credentials
-        raise ResponseError.new(code: response.code, body: response.body) if response.code != 200
 
         hash = JSON.parse(response.body)
         hash['PaymentID'] = hash['payout_id'] # Keep consistent with the normal payout response body
 
         create_response(hash)
-      rescue RestClient::BadRequest, RestClient::ResourceNotFound => e
-        hash = JSON.parse(e.response)
-
-        create_response(hash)
+      rescue RestClient::Exception => e
+        if e.http_body
+          hash = JSON.parse(e.http_body)
+          create_response(hash)
+        end
       end
     end
 

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -77,7 +77,7 @@ module Payoneer
       rescue RestClient::Exception => e
         if e.http_body
           hash = JSON.parse(e.http_body)
-          create_response(hash)
+          create_response(hash, e.http_code)
         end
       end
     end
@@ -109,12 +109,12 @@ module Payoneer
       end
     end
 
-    def create_response(hash)
+    def create_response(hash, http_code)
       if hash.key?('Code')
         Response.new(hash['Code'], hash['Description'])
       else
         hash = block_given? ? yield(hash) : hash
-        Response.new(Response::OK_STATUS_CODE, hash)
+        Response.new(http_code, hash)
       end
     end
   end

--- a/lib/payoneer/client.rb
+++ b/lib/payoneer/client.rb
@@ -109,7 +109,7 @@ module Payoneer
       end
     end
 
-    def create_response(hash, http_code=Response::OK_STATUS_CODE)
+    def create_response(hash, http_code = Response::OK_STATUS_CODE)
       if hash.key?('Code')
         Response.new(hash['Code'], hash['Description'])
       else

--- a/payoneer-client.gemspec
+++ b/payoneer-client.gemspec
@@ -3,7 +3,7 @@
 # gem push payoneer-client-{VERSION}.gem
 Gem::Specification.new do |s|
   s.name        = 'payoneer-client'
-  s.version     = '0.5'
+  s.version     = '0.4.1'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']

--- a/payoneer-client.gemspec
+++ b/payoneer-client.gemspec
@@ -3,7 +3,7 @@
 # gem push payoneer-client-{VERSION}.gem
 Gem::Specification.new do |s|
   s.name        = 'payoneer-client'
-  s.version     = '0.4'
+  s.version     = '0.5'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']


### PR DESCRIPTION
With the expanded payout, a validation error results in a Restclient error, resulting in just a response such as `400 Bad Request`. This change rescues from Restclient errors that would cause this and instead creates a Response object that gives more information.

Example response object would be:
`#<Payoneer::Response:0x007fd30cc412b0 @code="000", @body={"audit_id"=>35954306, "code"=>10403, "description"=>"Minimum limit is not met"}>`