### PR TITLE
Support HTTP config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ client.payee_details('fake-payee-id').body
     
 ```
 
+##### Advanced HTTP Client Options
+
+If you need to do additional configuration on the underlying HTTP client (RestClient), you can pass additional config under an `http_client_options` key and this will be passed through directly to the HTTP client.
+
+```ruby
+client = Payoneer::Client.new(
+  Payoneer::Configuration.new(
+    username: 'fake-username',
+    api_password: 'fake-api-password',
+    partner_id: 'fake-partner-id',
+    http_client_options: {
+      verify_ssl: true
+    }
+  )
+)
+```
+
 ##### Performing a normal payout:
 ```ruby
 response = client.payout(

--- a/lib/payoneer/configuration.rb
+++ b/lib/payoneer/configuration.rb
@@ -1,13 +1,14 @@
 module Payoneer
   class Configuration
-    attr_reader :partner_id, :username, :api_password, :auto_approve_sandbox_accounts
+    attr_reader :partner_id, :username, :api_password, :auto_approve_sandbox_accounts, :http_client_options
 
-    def initialize(partner_id:, username:, api_password:, environment: 'development', auto_approve_sandbox_accounts: true)
+    def initialize(partner_id:, username:, api_password:, environment: 'development', auto_approve_sandbox_accounts: true, http_client_options: {})
       @partner_id                    = partner_id
       @username                      = username
       @api_password                  = api_password
       @host                          = 'api.sandbox.payoneer.com' if environment != 'production'
       @auto_approve_sandbox_accounts = auto_approve_sandbox_accounts && environment != 'production'
+      @http_client_options           = http_client_options
     end
 
     def protocol

--- a/payoneer-client.gemspec
+++ b/payoneer-client.gemspec
@@ -3,11 +3,11 @@
 # gem push payoneer-client-{VERSION}.gem
 Gem::Specification.new do |s|
   s.name        = 'payoneer-client'
-  s.version     = '0.4.1'
+  s.version     = '0.5.0'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
-  s.authors     = ['Chris Estreich']
-  s.email       = ['chris@tophatter.com']
+  s.authors     = ['Chris Estreich', 'Todd Eichel']
+  s.email       = ['chris@tophatter.com', 'todd@tophatter.com']
   s.homepage    = 'https://github.com/tophatter/payoneer-api-ruby'
   s.summary     = 'Payoneer SDK for ruby.'
   s.description = 'Payoneer SDK for ruby.'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -147,7 +147,7 @@ describe Payoneer::Client do
 
     it 'passes HTTP client options to HTTP client' do
       expect(RestClient::Request).to receive(:execute).with(hash_including(verify_ssl: true)).and_return(response)
-      response = client.status
+      client.status
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -10,7 +10,9 @@ describe Payoneer::Client do
   end
 
   let(:endpoint) { 'https://api.payoneer.com/Payouts/HttpApi/API.aspx' }
-  let(:configuration) { Payoneer::Configuration.new(username: 'fake-username', api_password: 'fake-password', partner_id: 'fake-partner-id', environment: 'production') }
+  let(:default_config_options) { { username: 'fake-username', api_password: 'fake-password', partner_id: 'fake-partner-id', environment: 'production' } }
+  let(:config_options) { default_config_options }
+  let(:configuration) { Payoneer::Configuration.new(config_options) }
   let(:client) { Payoneer::Client.new(configuration) }
 
   describe '#status' do
@@ -18,7 +20,7 @@ describe Payoneer::Client do
       let(:xml) { "<?xml version='1.0' encoding='ISO-8859-1' ?><PayoneerResponse><Status>000</Status><Description>Echo Ok - All systems are up.</Description></PayoneerResponse>" }
 
       it 'returns a successful response' do
-        expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, hash_including(mname: 'Echo')).and_return(response)
+        expect(RestClient::Request).to receive(:execute).exactly(1).times.with(method: :post, url: endpoint, payload: hash_including(mname: 'Echo')).and_return(response)
         response = client.status
         expect(response.ok?).to be_truthy
         expect(response.body['Description']).to eq('Echo Ok - All systems are up.')
@@ -29,7 +31,7 @@ describe Payoneer::Client do
       let(:xml) { "<?xml version='1.0' encoding='ISO-8859-1' ?><PayoneerResponse><Code>999</Code><Description>Echo Failure - All systems are down.</Description></PayoneerResponse>" }
 
       it 'returns a failure response' do
-        expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, hash_including(mname: 'Echo')).and_return(response)
+        expect(RestClient::Request).to receive(:execute).exactly(1).times.with(method: :post, url: endpoint, payload: hash_including(mname: 'Echo')).and_return(response)
         response = client.status
         expect(response.ok?).to be_falsey
         expect(response.body).to eq('Echo Failure - All systems are down.')
@@ -45,7 +47,7 @@ describe Payoneer::Client do
       end
 
       it 'raises an error' do
-        expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, hash_including(mname: 'Echo')).and_return(response)
+        expect(RestClient::Request).to receive(:execute).exactly(1).times.with(method: :post, url: endpoint, payload: hash_including(mname: 'Echo')).and_return(response)
         expect { client.status }.to raise_error(Payoneer::ResponseError)
       end
     end
@@ -55,7 +57,7 @@ describe Payoneer::Client do
     let(:xml) { "<?xml version='1.0' encoding='ISO-8859-1' ?><PayoneerResponse><Version>4.15</Version></PayoneerResponse>" }
 
     it 'generates the correct request' do
-      expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, hash_including(mname: 'GetVersion')).and_return(response)
+      expect(RestClient::Request).to receive(:execute).exactly(1).times.with(method: :post, url: endpoint, payload: hash_including(mname: 'GetVersion')).and_return(response)
       response = client.version
       expect(response.ok?).to be_truthy
       expect(response.body['Version']).to eq('4.15')
@@ -66,7 +68,7 @@ describe Payoneer::Client do
     let(:xml) { '<?xml version="1.0" encoding="UTF-8" ?><PayoneerToken><Token>https://payouts.sandbox.payoneer.com/partners/lp.aspx?token=fake-token</Token></PayoneerToken>' }
 
     it 'generates the correct request' do
-      expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, hash_including(mname: 'GetToken')).and_return(response)
+      expect(RestClient::Request).to receive(:execute).exactly(1).times.with(method: :post, url: endpoint, payload: hash_including(mname: 'GetToken')).and_return(response)
       response = client.payee_signup_url('test')
       expect(response.ok?).to be_truthy
       expect(response.body).to eq('https://payouts.sandbox.payoneer.com/partners/lp.aspx?token=fake-token')
@@ -77,7 +79,7 @@ describe Payoneer::Client do
     let(:xml) { '<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?><GetPayeeDetails><Payee><FirstName>Foo</FirstName><LastName>Bar</LastName><Email>foo@bar.com</Email><Address1>185 Berry Street</Address1><Address2>Suite 2400</Address2><City>San Francisco</City><State>CA</State><Zip>94107</Zip><Country>US</Country><Phone></Phone><Mobile>15552223333</Mobile><PayeeStatus>Active</PayeeStatus><PayOutMethod>Prepaid Card</PayOutMethod><Cards><Card><CardID>123456789</CardID><Currency>USD</Currency><ActivationStatus>Card Issued, Not Activated</ActivationStatus><CardShipDate>11/25/2015</CardShipDate><CardStatus>Active</CardStatus></Card></Cards><RegDate>10/9/2017 7:58:44 PM</RegDate></Payee><CompanyDetails><CompanyName></CompanyName></CompanyDetails></GetPayeeDetails>' }
 
     it 'generates the correct request' do
-      expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, hash_including(mname: 'GetPayeeDetails')).and_return(response)
+      expect(RestClient::Request).to receive(:execute).exactly(1).times.with(method: :post, url: endpoint, payload: hash_including(mname: 'GetPayeeDetails')).and_return(response)
       response = client.payee_details('fake-payee-id')
       expect(response.ok?).to be_truthy
       expect(response.body).to include('FirstName' => 'Foo', 'LastName' => 'Bar')
@@ -129,13 +131,23 @@ describe Payoneer::Client do
     end
 
     it 'generates the correct response' do
-      expect(RestClient).to receive(:post).exactly(1).times.with(endpoint, params.to_json, headers).and_return(response)
+      expect(RestClient::Request).to receive(:execute).exactly(1).times.with(method: :post, url: endpoint, payload: params.to_json, headers: headers).and_return(response)
       response = client.expanded_payout(payee_id: payee_id, client_reference_id: client_reference_id, amount: amount, description: description, currency: currency, seller_id: seller_id, seller_name: seller_name, seller_url: seller_url, path: path, credentials: credentials)
       expect(response.ok?).to be_truthy
       expect(response.body).to include('payee_id' => payee_id, 'amount' => amount)
       expect(response.body).to include('orders_report')
       expect(response.body['orders_report']).to include('orders')
       expect(response.body['orders_report']['orders']).to include('path' => path)
+    end
+  end
+
+  describe 'configuration' do
+    let(:config_options) { default_config_options.merge(http_client_options: { verify_ssl: true }) }
+    let(:xml) { "<?xml version='1.0' encoding='ISO-8859-1' ?><PayoneerResponse><Status>000</Status><Description>Echo Ok - All systems are up.</Description></PayoneerResponse>" }
+
+    it 'passes HTTP client options to HTTP client' do
+      expect(RestClient::Request).to receive(:execute).with(hash_including(verify_ssl: true)).and_return(response)
+      response = client.status
     end
   end
 end


### PR DESCRIPTION
Some use cases may require passing additional configuration to the underlying HTTP client (RestClient).

This adds a config key (`http_client_options`), the value of which will be passed through directly to the HTTP client.
