### PR TITLE
Allow passing a custom API host to config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,21 @@ client.payee_details('fake-payee-id').body
     
 ```
 
-##### Advanced HTTP Client Options
+##### Advanced Options
+
+If you need to interact with an API host other than the default Payoneer
+production/sandbox API URLs, you can pass a `host` option to the configuration:
+
+```ruby
+client = Payoneer::Client.new(
+  Payoneer::Configuration.new(
+    username: 'fake-username',
+    api_password: 'fake-api-password',
+    partner_id: 'fake-partner-id',
+    host: 'myspecial.api.payoneer.com'
+  )
+)
+```
 
 If you need to do additional configuration on the underlying HTTP client (RestClient), you can pass additional config under an `http_client_options` key and this will be passed through directly to the HTTP client.
 

--- a/lib/payoneer/configuration.rb
+++ b/lib/payoneer/configuration.rb
@@ -2,29 +2,35 @@ module Payoneer
   class Configuration
     attr_reader :partner_id, :username, :api_password, :auto_approve_sandbox_accounts, :http_client_options
 
-    def initialize(partner_id:, username:, api_password:, environment: 'development', auto_approve_sandbox_accounts: true, http_client_options: {})
+    def initialize(partner_id:, username:, api_password:, environment: 'development', protocol: 'https', host: nil, http_client_options: {}, auto_approve_sandbox_accounts: true)
       @partner_id                    = partner_id
       @username                      = username
       @api_password                  = api_password
-      @host                          = 'api.sandbox.payoneer.com' if environment != 'production'
-      @auto_approve_sandbox_accounts = auto_approve_sandbox_accounts && environment != 'production'
+      @environment                   = environment
+
+      @protocol                      = protocol
+      @host                          = host || default_host
       @http_client_options           = http_client_options
-    end
 
-    def protocol
-      @protocol || 'https'
-    end
-
-    def host
-      @host || 'api.payoneer.com'
+      @auto_approve_sandbox_accounts = auto_approve_sandbox_accounts && environment != 'production'
     end
 
     def xml_base_uri
-      @xml_base_uri || "#{protocol}://#{host}/Payouts/HttpApi/API.aspx"
+      "#{@protocol}://#{@host}/Payouts/HttpApi/API.aspx"
     end
 
     def json_base_uri
-      @json_base_uri || "#{protocol}://#{host}/v2/programs/#{@partner_id}"
+      "#{@protocol}://#{@host}/v2/programs/#{@partner_id}"
+    end
+
+    private
+
+    def default_host
+      if @environment == 'production'
+        'api.payoneer.com'
+      else
+        'api.sandbox.payoneer.com'
+      end
     end
   end
 end

--- a/payoneer-client.gemspec
+++ b/payoneer-client.gemspec
@@ -3,7 +3,7 @@
 # gem push payoneer-client-{VERSION}.gem
 Gem::Specification.new do |s|
   s.name        = 'payoneer-client'
-  s.version     = '0.5.0'
+  s.version     = '0.6.0'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich', 'Todd Eichel']

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -142,12 +142,23 @@ describe Payoneer::Client do
   end
 
   describe 'configuration' do
-    let(:config_options) { default_config_options.merge(http_client_options: { verify_ssl: true }) }
     let(:xml) { "<?xml version='1.0' encoding='ISO-8859-1' ?><PayoneerResponse><Status>000</Status><Description>Echo Ok - All systems are up.</Description></PayoneerResponse>" }
 
-    it 'passes HTTP client options to HTTP client' do
-      expect(RestClient::Request).to receive(:execute).with(hash_including(verify_ssl: true)).and_return(response)
-      client.status
+    describe 'http_client_options' do
+      let(:config_options) { default_config_options.merge(http_client_options: { verify_ssl: true }) }
+      it 'passes HTTP client options to HTTP client' do
+        expect(RestClient::Request).to receive(:execute).with(hash_including(verify_ssl: true)).and_return(response)
+        client.status
+      end
+    end
+
+    describe 'host' do
+      let(:config_options) { default_config_options.merge(host: 'api.example.com') }
+      it 'allows using a custom API host' do
+        expected_url = 'https://api.example.com/Payouts/HttpApi/API.aspx'
+        expect(RestClient::Request).to receive(:execute).with(hash_including(url: expected_url)).and_return(response)
+        client.status
+      end
     end
   end
 end


### PR DESCRIPTION
Also clean up config options handling.